### PR TITLE
feat: 暗号化・復号化システムの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -15,15 +18,20 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@peculiar/webcrypto": "^1.5.0",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/ui": "^3.1.4",
     "eslint": "^9.13.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
+    "jsdom": "^26.1.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
-    "vite": "^5.4.10"
+    "vite": "^5.4.10",
+    "vitest": "^3.1.4"
   }
 }

--- a/src/crypto/CryptoService.ts
+++ b/src/crypto/CryptoService.ts
@@ -1,0 +1,244 @@
+import {
+  KeyPair,
+  ExportedKeyPair,
+  EncryptedData,
+  SerializedEncryptedData,
+  TileValue,
+  EncryptedTile
+} from '../types/crypto';
+
+export class CryptoService {
+  private static readonly ECDH_ALGORITHM = 'ECDH';
+  private static readonly CURVE = 'P-256';
+  private static readonly AES_ALGORITHM = 'AES-GCM';
+  private static readonly AES_KEY_LENGTH = 256;
+
+  static async generateKeyPair(): Promise<KeyPair> {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: this.ECDH_ALGORITHM,
+        namedCurve: this.CURVE,
+      },
+      true,
+      ['deriveKey']
+    );
+
+    return keyPair;
+  }
+
+  static async exportKeyPair(keyPair: KeyPair): Promise<ExportedKeyPair> {
+    const publicKey = await crypto.subtle.exportKey('jwk', keyPair.publicKey);
+    const privateKey = await crypto.subtle.exportKey('jwk', keyPair.privateKey);
+    
+    return { publicKey, privateKey };
+  }
+
+  static async importPublicKey(jwk: JsonWebKey): Promise<CryptoKey> {
+    return crypto.subtle.importKey(
+      'jwk',
+      jwk,
+      {
+        name: this.ECDH_ALGORITHM,
+        namedCurve: this.CURVE,
+      },
+      true,
+      []
+    );
+  }
+
+  static async importPrivateKey(jwk: JsonWebKey): Promise<CryptoKey> {
+    return crypto.subtle.importKey(
+      'jwk',
+      jwk,
+      {
+        name: this.ECDH_ALGORITHM,
+        namedCurve: this.CURVE,
+      },
+      true,
+      ['deriveKey']
+    );
+  }
+
+  static async importKeyPair(exported: ExportedKeyPair): Promise<KeyPair> {
+    const publicKey = await this.importPublicKey(exported.publicKey);
+    const privateKey = await this.importPrivateKey(exported.privateKey);
+    
+    return { publicKey, privateKey };
+  }
+
+  private static async deriveSharedKey(
+    privateKey: CryptoKey,
+    publicKey: CryptoKey
+  ): Promise<CryptoKey> {
+    return crypto.subtle.deriveKey(
+      {
+        name: this.ECDH_ALGORITHM,
+        public: publicKey,
+      },
+      privateKey,
+      {
+        name: this.AES_ALGORITHM,
+        length: this.AES_KEY_LENGTH,
+      },
+      true,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  static async encrypt(
+    data: ArrayBuffer,
+    recipientPublicKey: CryptoKey
+  ): Promise<EncryptedData> {
+    // Generate ephemeral key pair for this encryption
+    const ephemeralKeyPair = await this.generateKeyPair();
+    
+    // Derive shared key
+    const sharedKey = await this.deriveSharedKey(
+      ephemeralKeyPair.privateKey,
+      recipientPublicKey
+    );
+
+    // Generate IV
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    // Encrypt data
+    const ciphertext = await crypto.subtle.encrypt(
+      {
+        name: this.AES_ALGORITHM,
+        iv: iv,
+      },
+      sharedKey,
+      data
+    );
+
+    // Export ephemeral public key
+    const ephemeralPublicKey = await crypto.subtle.exportKey(
+      'jwk',
+      ephemeralKeyPair.publicKey
+    );
+
+    return {
+      ciphertext,
+      iv,
+      ephemeralPublicKey,
+    };
+  }
+
+  static async decrypt(
+    encryptedData: EncryptedData,
+    recipientPrivateKey: CryptoKey
+  ): Promise<ArrayBuffer> {
+    // Import ephemeral public key
+    const ephemeralPublicKey = await this.importPublicKey(
+      encryptedData.ephemeralPublicKey
+    );
+
+    // Derive shared key
+    const sharedKey = await this.deriveSharedKey(
+      recipientPrivateKey,
+      ephemeralPublicKey
+    );
+
+    // Decrypt data
+    const plaintext = await crypto.subtle.decrypt(
+      {
+        name: this.AES_ALGORITHM,
+        iv: encryptedData.iv,
+      },
+      sharedKey,
+      encryptedData.ciphertext
+    );
+
+    return plaintext;
+  }
+
+  static serializeEncryptedData(data: EncryptedData): SerializedEncryptedData {
+    return {
+      ciphertext: this.arrayBufferToBase64(data.ciphertext),
+      iv: this.arrayBufferToBase64(data.iv),
+      ephemeralPublicKey: data.ephemeralPublicKey,
+    };
+  }
+
+  static deserializeEncryptedData(data: SerializedEncryptedData): EncryptedData {
+    return {
+      ciphertext: this.base64ToArrayBuffer(data.ciphertext),
+      iv: new Uint8Array(this.base64ToArrayBuffer(data.iv)),
+      ephemeralPublicKey: data.ephemeralPublicKey,
+    };
+  }
+
+  private static arrayBufferToBase64(buffer: ArrayBuffer): string {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    bytes.forEach((b) => binary += String.fromCharCode(b));
+    return btoa(binary);
+  }
+
+  private static base64ToArrayBuffer(base64: string): ArrayBuffer {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  static async encryptTile(
+    tileValue: TileValue,
+    publicKeys: CryptoKey[]
+  ): Promise<EncryptedTile> {
+    const encoder = new TextEncoder();
+    let data = encoder.encode(tileValue);
+    const encryptedLayers: SerializedEncryptedData[] = [];
+
+    // Apply encryption in order
+    for (const publicKey of publicKeys) {
+      const encrypted = await this.encrypt(data, publicKey);
+      encryptedLayers.push(this.serializeEncryptedData(encrypted));
+      
+      // Use the ciphertext as input for next layer
+      data = new Uint8Array(encrypted.ciphertext);
+    }
+
+    return {
+      id: crypto.randomUUID(),
+      encryptedData: encryptedLayers,
+    };
+  }
+
+  static async decryptTile(
+    encryptedTile: EncryptedTile,
+    privateKeys: CryptoKey[]
+  ): Promise<TileValue> {
+    if (encryptedTile.encryptedData.length !== privateKeys.length) {
+      throw new Error('Number of encryption layers does not match number of keys');
+    }
+
+    let currentData: ArrayBuffer | undefined;
+
+    // Decrypt in reverse order (D -> C -> B -> A)
+    // privateKeys are already in reverse order, encryptedData is in forward order
+    for (let i = privateKeys.length - 1; i >= 0; i--) {
+      const encryptedLayer = this.deserializeEncryptedData(encryptedTile.encryptedData[i]);
+      
+      // For the outermost layer, use the encrypted data as is
+      // For inner layers, use the result from the previous decryption
+      if (i === privateKeys.length - 1) {
+        currentData = await this.decrypt(encryptedLayer, privateKeys[privateKeys.length - 1 - i]);
+      } else {
+        // The current data is the ciphertext for the next layer
+        encryptedLayer.ciphertext = currentData!;
+        currentData = await this.decrypt(encryptedLayer, privateKeys[privateKeys.length - 1 - i]);
+      }
+    }
+
+    if (!currentData) {
+      throw new Error('Decryption failed');
+    }
+
+    // Final result should be the original tile value
+    const decoder = new TextDecoder();
+    return decoder.decode(currentData);
+  }
+}

--- a/src/crypto/GameSession.ts
+++ b/src/crypto/GameSession.ts
@@ -1,0 +1,168 @@
+import { CryptoService } from './CryptoService';
+import { TileShuffleService } from './TileShuffleService';
+import { KeyPair, EncryptedTile, TileValue } from '../types/crypto';
+
+export interface Player {
+  id: string;
+  name: string;
+  keyPair?: KeyPair;
+  exportedPublicKey?: JsonWebKey;
+}
+
+export class GameSession {
+  private players: Player[] = [];
+  private encryptedDeck: EncryptedTile[] = [];
+  private currentPlayerIndex: number = 0;
+
+  constructor() {}
+
+  async addPlayer(id: string, name: string): Promise<Player> {
+    if (this.players.length >= 4) {
+      throw new Error('Game session is full (4 players max)');
+    }
+
+    const keyPair = await CryptoService.generateKeyPair();
+    const exported = await CryptoService.exportKeyPair(keyPair);
+    
+    const player: Player = {
+      id,
+      name,
+      keyPair,
+      exportedPublicKey: exported.publicKey
+    };
+
+    this.players.push(player);
+    return player;
+  }
+
+  getPlayers(): Player[] {
+    return this.players;
+  }
+
+  async getAllPublicKeys(): Promise<CryptoKey[]> {
+    const publicKeys: CryptoKey[] = [];
+    
+    for (const player of this.players) {
+      if (player.exportedPublicKey) {
+        const publicKey = await CryptoService.importPublicKey(player.exportedPublicKey);
+        publicKeys.push(publicKey);
+      }
+    }
+    
+    return publicKeys;
+  }
+
+  async initializeDeck(): Promise<EncryptedTile[]> {
+    if (this.players.length !== 4) {
+      throw new Error('Need exactly 4 players to initialize deck');
+    }
+
+    // Generate the initial tile set
+    const tiles = TileShuffleService.generateFullTileSet();
+    
+    // Get all public keys in order (A -> B -> C -> D)
+    const allPublicKeys = await this.getAllPublicKeys();
+    
+    // First player encrypts with all keys and shuffles
+    this.encryptedDeck = await TileShuffleService.encryptAndShuffleTiles(
+      tiles,
+      allPublicKeys[0],
+      allPublicKeys
+    );
+
+    return this.encryptedDeck;
+  }
+
+  async playerShuffleDeck(playerId: string): Promise<EncryptedTile[]> {
+    const playerIndex = this.players.findIndex(p => p.id === playerId);
+    
+    if (playerIndex === -1) {
+      throw new Error('Player not found');
+    }
+
+    // Players 2-4 just shuffle the already encrypted deck
+    this.encryptedDeck = TileShuffleService.shuffleArray(this.encryptedDeck);
+    
+    return this.encryptedDeck;
+  }
+
+  getEncryptedDeck(): EncryptedTile[] {
+    return this.encryptedDeck;
+  }
+
+  async decryptTileForPlayer(
+    tileIndex: number,
+    playerId: string
+  ): Promise<TileValue> {
+    const player = this.players.find(p => p.id === playerId);
+    
+    if (!player || !player.keyPair) {
+      throw new Error('Player not found or no key pair');
+    }
+
+    if (tileIndex < 0 || tileIndex >= this.encryptedDeck.length) {
+      throw new Error('Invalid tile index');
+    }
+
+    const encryptedTile = this.encryptedDeck[tileIndex];
+    
+    // Get all private keys in reverse order for this player
+    const privateKeys: CryptoKey[] = [];
+    
+    // We need all players' private keys in reverse order (D -> C -> B -> A)
+    // In a real game, each player would only have their own private key
+    // and would need cooperation to decrypt
+    for (let i = this.players.length - 1; i >= 0; i--) {
+      if (this.players[i].keyPair) {
+        privateKeys.push(this.players[i].keyPair!.privateKey);
+      }
+    }
+
+    return CryptoService.decryptTile(encryptedTile, privateKeys);
+  }
+
+  // Helper method for testing - in real game this would require all players' cooperation
+  async decryptTileWithAllKeys(tileIndex: number): Promise<TileValue> {
+    if (tileIndex < 0 || tileIndex >= this.encryptedDeck.length) {
+      throw new Error('Invalid tile index');
+    }
+
+    const encryptedTile = this.encryptedDeck[tileIndex];
+    const privateKeys: CryptoKey[] = [];
+    
+    // Collect all private keys in reverse order (D -> C -> B -> A)
+    for (let i = this.players.length - 1; i >= 0; i--) {
+      if (this.players[i].keyPair) {
+        privateKeys.push(this.players[i].keyPair!.privateKey);
+      }
+    }
+
+    return CryptoService.decryptTile(encryptedTile, privateKeys);
+  }
+
+  // Distribution methods for initial hand
+  getPlayerHandIndices(playerIndex: number): number[] {
+    // Each player gets 13 tiles initially (East gets 14)
+    const tilesPerPlayer = playerIndex === 0 ? 14 : 13;
+    const indices: number[] = [];
+    
+    // Simple distribution: player 0 gets tiles 0-13, player 1 gets 14-26, etc.
+    const startIndex = playerIndex === 0 ? 0 : 14 + (playerIndex - 1) * 13;
+    
+    for (let i = 0; i < tilesPerPlayer; i++) {
+      indices.push(startIndex + i);
+    }
+    
+    return indices;
+  }
+
+  // Get the next tile index for drawing
+  getNextDrawIndex(): number {
+    // After initial distribution, tiles are drawn from index 53 onwards
+    const initialTilesDistributed = 14 + 13 * 3; // 53 tiles
+    const remainingTiles = 136 - initialTilesDistributed;
+    
+    // This is simplified - in a real game, you'd track which tiles have been drawn
+    return initialTilesDistributed + Math.floor(Math.random() * remainingTiles);
+  }
+}

--- a/src/crypto/TileShuffleService.ts
+++ b/src/crypto/TileShuffleService.ts
@@ -1,0 +1,70 @@
+import { CryptoService } from './CryptoService';
+import { EncryptedTile, TileValue } from '../types/crypto';
+
+export class TileShuffleService {
+  static shuffleArray<T>(array: T[]): T[] {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+  }
+
+  static async encryptAndShuffleTiles(
+    tiles: TileValue[] | EncryptedTile[],
+    playerPublicKey: CryptoKey,
+    allPublicKeys: CryptoKey[] = []
+  ): Promise<EncryptedTile[]> {
+    // Shuffle first
+    const shuffled = this.shuffleArray(tiles);
+
+    if (allPublicKeys.length > 0) {
+      // Initial encryption by first player with all keys
+      const encrypted: EncryptedTile[] = [];
+      for (const tile of shuffled as TileValue[]) {
+        const encryptedTile = await CryptoService.encryptTile(tile, allPublicKeys);
+        encrypted.push(encryptedTile);
+      }
+      return encrypted;
+    } else {
+      // Just shuffle already encrypted tiles (for players 2-4)
+      return shuffled as EncryptedTile[];
+    }
+  }
+
+  static generateFullTileSet(): TileValue[] {
+    const tiles: TileValue[] = [];
+    
+    // 万子 (1-9) x 4
+    for (let i = 1; i <= 9; i++) {
+      for (let j = 0; j < 4; j++) {
+        tiles.push(`${i}m`);
+      }
+    }
+    
+    // 筒子 (1-9) x 4
+    for (let i = 1; i <= 9; i++) {
+      for (let j = 0; j < 4; j++) {
+        tiles.push(`${i}p`);
+      }
+    }
+    
+    // 索子 (1-9) x 4
+    for (let i = 1; i <= 9; i++) {
+      for (let j = 0; j < 4; j++) {
+        tiles.push(`${i}s`);
+      }
+    }
+    
+    // 字牌 (東南西北白發中) x 4
+    const honors = ['E', 'S', 'W', 'N', 'B', 'G', 'R'];
+    for (const honor of honors) {
+      for (let j = 0; j < 4; j++) {
+        tiles.push(honor);
+      }
+    }
+    
+    return tiles; // Total: 136 tiles
+  }
+}

--- a/src/crypto/__tests__/CryptoService.test.ts
+++ b/src/crypto/__tests__/CryptoService.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { CryptoService } from '../CryptoService';
+
+describe('CryptoService', () => {
+  it('should generate a valid key pair', async () => {
+    const keyPair = await CryptoService.generateKeyPair();
+    
+    expect(keyPair.publicKey).toBeDefined();
+    expect(keyPair.privateKey).toBeDefined();
+    expect(keyPair.publicKey.type).toBe('public');
+    expect(keyPair.privateKey.type).toBe('private');
+  });
+
+  it('should export and import key pairs', async () => {
+    const keyPair = await CryptoService.generateKeyPair();
+    const exported = await CryptoService.exportKeyPair(keyPair);
+    
+    expect(exported.publicKey).toBeDefined();
+    expect(exported.privateKey).toBeDefined();
+    
+    const imported = await CryptoService.importKeyPair(exported);
+    expect(imported.publicKey).toBeDefined();
+    expect(imported.privateKey).toBeDefined();
+  });
+
+  it('should encrypt and decrypt data', async () => {
+    const keyPair = await CryptoService.generateKeyPair();
+    const testData = 'Hello, Mahjong!';
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    
+    const encrypted = await CryptoService.encrypt(
+      encoder.encode(testData),
+      keyPair.publicKey
+    );
+    
+    expect(encrypted.ciphertext).toBeDefined();
+    expect(encrypted.iv).toBeDefined();
+    expect(encrypted.ephemeralPublicKey).toBeDefined();
+    
+    const decrypted = await CryptoService.decrypt(encrypted, keyPair.privateKey);
+    const decryptedText = decoder.decode(decrypted);
+    
+    expect(decryptedText).toBe(testData);
+  });
+
+  it('should handle multi-layer encryption for tiles', async () => {
+    // Generate 4 key pairs for 4 players
+    const keyPairs = await Promise.all([
+      CryptoService.generateKeyPair(),
+      CryptoService.generateKeyPair(),
+      CryptoService.generateKeyPair(),
+      CryptoService.generateKeyPair(),
+    ]);
+    
+    const publicKeys = keyPairs.map(kp => kp.publicKey);
+    const privateKeys = keyPairs.map(kp => kp.privateKey);
+    
+    const tileValue = '1m'; // 1 man
+    
+    // Encrypt tile with all 4 public keys
+    const encryptedTile = await CryptoService.encryptTile(tileValue, publicKeys);
+    
+    expect(encryptedTile.id).toBeDefined();
+    expect(encryptedTile.encryptedData).toHaveLength(4);
+    
+    // Decrypt tile with all 4 private keys in reverse order
+    const decryptedValue = await CryptoService.decryptTile(encryptedTile, privateKeys.reverse());
+    
+    expect(decryptedValue).toBe(tileValue);
+  });
+
+  it('should fail decryption with wrong keys', async () => {
+    const keyPair1 = await CryptoService.generateKeyPair();
+    const keyPair2 = await CryptoService.generateKeyPair();
+    
+    const tileValue = '9p'; // 9 pin
+    const encryptedTile = await CryptoService.encryptTile(tileValue, [keyPair1.publicKey]);
+    
+    // Try to decrypt with wrong private key
+    await expect(
+      CryptoService.decryptTile(encryptedTile, [keyPair2.privateKey])
+    ).rejects.toThrow();
+  });
+
+  it('should serialize and deserialize encrypted data', async () => {
+    const keyPair = await CryptoService.generateKeyPair();
+    const testData = new TextEncoder().encode('Test data');
+    
+    const encrypted = await CryptoService.encrypt(testData, keyPair.publicKey);
+    const serialized = CryptoService.serializeEncryptedData(encrypted);
+    
+    expect(typeof serialized.ciphertext).toBe('string');
+    expect(typeof serialized.iv).toBe('string');
+    expect(serialized.ephemeralPublicKey).toBeDefined();
+    
+    const deserialized = CryptoService.deserializeEncryptedData(serialized);
+    const decrypted = await CryptoService.decrypt(deserialized, keyPair.privateKey);
+    
+    expect(new TextDecoder().decode(decrypted)).toBe('Test data');
+  });
+});

--- a/src/crypto/__tests__/GameSession.test.ts
+++ b/src/crypto/__tests__/GameSession.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { GameSession } from '../GameSession';
+
+describe('GameSession', () => {
+  it('should add players and generate key pairs', async () => {
+    const session = new GameSession();
+    
+    const player1 = await session.addPlayer('p1', 'Alice');
+    await session.addPlayer('p2', 'Bob');
+    
+    expect(player1.keyPair).toBeDefined();
+    expect(player1.exportedPublicKey).toBeDefined();
+    expect(session.getPlayers()).toHaveLength(2);
+  });
+
+  it('should not allow more than 4 players', async () => {
+    const session = new GameSession();
+    
+    await session.addPlayer('p1', 'Alice');
+    await session.addPlayer('p2', 'Bob');
+    await session.addPlayer('p3', 'Charlie');
+    await session.addPlayer('p4', 'David');
+    
+    await expect(session.addPlayer('p5', 'Eve')).rejects.toThrow('Game session is full');
+  });
+
+  it('should initialize and encrypt deck with 4 players', async () => {
+    const session = new GameSession();
+    
+    // Add 4 players
+    await session.addPlayer('p1', 'Alice');
+    await session.addPlayer('p2', 'Bob');
+    await session.addPlayer('p3', 'Charlie');
+    await session.addPlayer('p4', 'David');
+    
+    // Initialize deck
+    const deck = await session.initializeDeck();
+    
+    expect(deck).toHaveLength(136); // Full mahjong tile set
+    expect(deck[0].encryptedData).toHaveLength(4); // 4 layers of encryption
+  });
+
+  it('should shuffle deck for each player', async () => {
+    const session = new GameSession();
+    
+    // Add 4 players
+    await session.addPlayer('p1', 'Alice');
+    await session.addPlayer('p2', 'Bob');
+    await session.addPlayer('p3', 'Charlie');
+    await session.addPlayer('p4', 'David');
+    
+    // Initialize deck
+    await session.initializeDeck();
+    const originalDeck = [...session.getEncryptedDeck()];
+    
+    // Player 2 shuffles
+    await session.playerShuffleDeck('p2');
+    const shuffledDeck = session.getEncryptedDeck();
+    
+    // Check that deck is shuffled (very unlikely to be in same order)
+    let differentOrder = false;
+    for (let i = 0; i < originalDeck.length; i++) {
+      if (originalDeck[i].id !== shuffledDeck[i].id) {
+        differentOrder = true;
+        break;
+      }
+    }
+    
+    expect(differentOrder).toBe(true);
+    expect(shuffledDeck).toHaveLength(136);
+  });
+
+  it('should correctly distribute initial tiles', async () => {
+    const session = new GameSession();
+    
+    // Add 4 players
+    await session.addPlayer('p1', 'East');
+    await session.addPlayer('p2', 'South');
+    await session.addPlayer('p3', 'West');
+    await session.addPlayer('p4', 'North');
+    
+    // Get hand indices
+    const eastHand = session.getPlayerHandIndices(0);
+    const southHand = session.getPlayerHandIndices(1);
+    const westHand = session.getPlayerHandIndices(2);
+    const northHand = session.getPlayerHandIndices(3);
+    
+    expect(eastHand).toHaveLength(14); // East gets 14 tiles
+    expect(southHand).toHaveLength(13);
+    expect(westHand).toHaveLength(13);
+    expect(northHand).toHaveLength(13);
+    
+    // Check no overlap
+    const allIndices = [...eastHand, ...southHand, ...westHand, ...northHand];
+    const uniqueIndices = new Set(allIndices);
+    expect(uniqueIndices.size).toBe(53); // Total initial tiles distributed
+  });
+
+  it('should decrypt tiles correctly', async () => {
+    const session = new GameSession();
+    
+    // Add 4 players
+    await session.addPlayer('p1', 'Alice');
+    await session.addPlayer('p2', 'Bob');
+    await session.addPlayer('p3', 'Charlie');
+    await session.addPlayer('p4', 'David');
+    
+    // Initialize deck
+    await session.initializeDeck();
+    
+    // Try to decrypt first tile using helper method (in real game, would need all players' cooperation)
+    const decryptedTile = await session.decryptTileWithAllKeys(0);
+    
+    // Check it's a valid tile
+    const validTilePattern = /^([1-9][mps]|[ESWNBGR])$/;
+    expect(decryptedTile).toMatch(validTilePattern);
+  });
+});

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,0 +1,5 @@
+export { CryptoService } from './CryptoService';
+export { TileShuffleService } from './TileShuffleService';
+export { GameSession } from './GameSession';
+export type { Player } from './GameSession';
+export * from '../types/crypto';

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,27 @@
+import { Crypto } from '@peculiar/webcrypto';
+
+// Polyfill WebCrypto API for tests
+const cryptoPolyfill = new Crypto();
+
+// @ts-expect-error crypto property is not defined in globalThis type
+globalThis.crypto = cryptoPolyfill;
+// @ts-expect-error crypto property is not defined in global type
+global.crypto = cryptoPolyfill;
+
+// Ensure window.crypto exists in jsdom environment
+if (typeof window !== 'undefined' && !window.crypto) {
+  // @ts-expect-error window.crypto assignment
+  window.crypto = cryptoPolyfill;
+}
+
+// Polyfill for crypto.randomUUID if not available
+if (!crypto.randomUUID) {
+  // @ts-expect-error adding randomUUID method
+  crypto.randomUUID = () => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  };
+}

--- a/src/types/crypto.ts
+++ b/src/types/crypto.ts
@@ -1,0 +1,28 @@
+export interface KeyPair {
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+}
+
+export interface ExportedKeyPair {
+  publicKey: JsonWebKey;
+  privateKey: JsonWebKey;
+}
+
+export interface EncryptedData {
+  ciphertext: ArrayBuffer;
+  iv: Uint8Array;
+  ephemeralPublicKey: JsonWebKey;
+}
+
+export interface SerializedEncryptedData {
+  ciphertext: string; // base64
+  iv: string; // base64
+  ephemeralPublicKey: JsonWebKey;
+}
+
+export type TileValue = string;
+
+export interface EncryptedTile {
+  id: string;
+  encryptedData: SerializedEncryptedData[];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: [resolve(__dirname, 'src/test-setup.ts')],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
- WebCrypto APIを使用したECDH+AES-GCM暗号化システムを実装
- 4段階の多層暗号化（各プレイヤーの公開鍵で暗号化）に対応
- 逆順での復号処理を実装（D→C→B→A）
- 麻雀牌136枚の生成とシャッフル機能を追加
- GameSessionクラスでプレイヤー管理と牌の配布を実装
- 包括的なテストケースを追加（vitest使用）

関連: #5