### PR TITLE
feat: 麻雀牌の生成・管理システムの実装

### DIFF
--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,0 +1,3 @@
+export * from '../types/tile';
+export * from '../utils/tileGenerator';
+export * from './tileManager';

--- a/src/game/tileManager.ts
+++ b/src/game/tileManager.ts
@@ -1,0 +1,158 @@
+import { Tile, TileWithState } from '../types/tile';
+import { generateFullTileSet, shuffleTiles } from '../utils/tileGenerator';
+
+export class TileManager {
+  private tiles: Map<string, TileWithState>;
+  private wall: string[];
+  private hands: Map<number, string[]>;
+  private discards: Map<number, string[]>;
+  private melds: Map<number, string[][]>;
+
+  constructor() {
+    this.tiles = new Map();
+    this.wall = [];
+    this.hands = new Map();
+    this.discards = new Map();
+    this.melds = new Map();
+  }
+
+  initialize(playerCount: number = 4): void {
+    // 牌を生成
+    const baseTiles = generateFullTileSet();
+    const shuffledTiles = shuffleTiles(baseTiles);
+
+    // 状態付きの牌として保存
+    shuffledTiles.forEach(tile => {
+      const tileWithState: TileWithState = {
+        ...tile,
+        state: 'wall'
+      };
+      this.tiles.set(tile.id, tileWithState);
+      this.wall.push(tile.id);
+    });
+
+    // プレイヤーごとの手牌・捨て牌・鳴き牌の初期化
+    for (let i = 0; i < playerCount; i++) {
+      this.hands.set(i, []);
+      this.discards.set(i, []);
+      this.melds.set(i, []);
+    }
+  }
+
+  // 牌を山から引く
+  drawTile(playerId: number): Tile | null {
+    if (this.wall.length === 0) return null;
+
+    const tileId = this.wall.shift()!;
+    const tile = this.tiles.get(tileId)!;
+    
+    tile.state = 'hand';
+    tile.owner = playerId;
+    
+    const playerHand = this.hands.get(playerId) || [];
+    playerHand.push(tileId);
+    this.hands.set(playerId, playerHand);
+
+    return { ...tile };
+  }
+
+  // 牌を捨てる
+  discardTile(playerId: number, tileId: string): boolean {
+    const tile = this.tiles.get(tileId);
+    if (!tile || tile.owner !== playerId || tile.state !== 'hand') {
+      return false;
+    }
+
+    // 手牌から削除
+    const playerHand = this.hands.get(playerId) || [];
+    const index = playerHand.indexOf(tileId);
+    if (index === -1) return false;
+    
+    playerHand.splice(index, 1);
+    this.hands.set(playerId, playerHand);
+
+    // 捨て牌に追加
+    tile.state = 'discard';
+    const playerDiscards = this.discards.get(playerId) || [];
+    playerDiscards.push(tileId);
+    this.discards.set(playerId, playerDiscards);
+
+    return true;
+  }
+
+  // 配牌を行う
+  dealInitialHands(handSize: number = 13): void {
+    const playerCount = this.hands.size;
+    
+    for (let i = 0; i < handSize; i++) {
+      for (let playerId = 0; playerId < playerCount; playerId++) {
+        this.drawTile(playerId);
+      }
+    }
+  }
+
+  // 特定のプレイヤーの手牌を取得
+  getPlayerHand(playerId: number): Tile[] {
+    const handIds = this.hands.get(playerId) || [];
+    return handIds.map(id => ({ ...this.tiles.get(id)! }));
+  }
+
+  // 山牌の残り枚数を取得
+  getWallCount(): number {
+    return this.wall.length;
+  }
+
+  // 捨て牌を取得
+  getDiscards(playerId: number): Tile[] {
+    const discardIds = this.discards.get(playerId) || [];
+    return discardIds.map(id => ({ ...this.tiles.get(id)! }));
+  }
+
+  // 全ての捨て牌を取得
+  getAllDiscards(): Map<number, Tile[]> {
+    const allDiscards = new Map<number, Tile[]>();
+    this.discards.forEach((discardIds, playerId) => {
+      allDiscards.set(playerId, discardIds.map(id => ({ ...this.tiles.get(id)! })));
+    });
+    return allDiscards;
+  }
+
+  // 牌を鳴く（ポン・チー・カン）
+  meldTiles(playerId: number, tileIds: string[]): boolean {
+    // 全ての牌が存在し、正しい状態であることを確認
+    for (const tileId of tileIds) {
+      const tile = this.tiles.get(tileId);
+      if (!tile) return false;
+    }
+
+    // 牌を鳴き牌として設定
+    tileIds.forEach(tileId => {
+      const tile = this.tiles.get(tileId)!;
+      
+      // 手牌から削除（自分の手牌にある場合）
+      if (tile.owner === playerId && tile.state === 'hand') {
+        const playerHand = this.hands.get(playerId) || [];
+        const index = playerHand.indexOf(tileId);
+        if (index !== -1) {
+          playerHand.splice(index, 1);
+          this.hands.set(playerId, playerHand);
+        }
+      }
+      
+      tile.state = 'meld';
+      tile.owner = playerId;
+    });
+
+    // 鳴き牌として登録
+    const playerMelds = this.melds.get(playerId) || [];
+    playerMelds.push(tileIds);
+    this.melds.set(playerId, playerMelds);
+
+    return true;
+  }
+
+  // 牌の状態を取得
+  getTileState(tileId: string): TileWithState | null {
+    return this.tiles.get(tileId) || null;
+  }
+}

--- a/src/types/tile.ts
+++ b/src/types/tile.ts
@@ -1,0 +1,23 @@
+export type TileType = 'man' | 'pin' | 'sou' | 'honor';
+
+export type HonorValue = 'E' | 'S' | 'W' | 'N' | 'haku' | 'hatsu' | 'chun';
+
+export interface Tile {
+  id: string;
+  type: TileType;
+  value: number | HonorValue;
+  encrypted?: boolean;
+}
+
+export interface EncryptedTile {
+  id: string;
+  encryptedData: string;
+  encryptionLayers: number;
+}
+
+export type TileState = 'wall' | 'hand' | 'discard' | 'meld';
+
+export interface TileWithState extends Tile {
+  state: TileState;
+  owner?: number;
+}

--- a/src/utils/tileGenerator.ts
+++ b/src/utils/tileGenerator.ts
@@ -1,0 +1,71 @@
+import { Tile, HonorValue } from '../types/tile';
+
+export function generateFullTileSet(): Tile[] {
+  const tiles: Tile[] = [];
+  let tileIdCounter = 0;
+
+  // 萬子 (1-9, 4枚ずつ)
+  for (let value = 1; value <= 9; value++) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({
+        id: `tile_${tileIdCounter++}`,
+        type: 'man',
+        value: value,
+      });
+    }
+  }
+
+  // 筒子 (1-9, 4枚ずつ)
+  for (let value = 1; value <= 9; value++) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({
+        id: `tile_${tileIdCounter++}`,
+        type: 'pin',
+        value: value,
+      });
+    }
+  }
+
+  // 索子 (1-9, 4枚ずつ)
+  for (let value = 1; value <= 9; value++) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({
+        id: `tile_${tileIdCounter++}`,
+        type: 'sou',
+        value: value,
+      });
+    }
+  }
+
+  // 字牌 (東南西北白發中, 4枚ずつ)
+  const honorValues: HonorValue[] = ['E', 'S', 'W', 'N', 'haku', 'hatsu', 'chun'];
+  for (const honorValue of honorValues) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({
+        id: `tile_${tileIdCounter++}`,
+        type: 'honor',
+        value: honorValue,
+      });
+    }
+  }
+
+  return tiles;
+}
+
+export function getTileNotation(tile: Tile): string {
+  if (tile.type === 'honor') {
+    return tile.value as string;
+  }
+  
+  const suffix = tile.type === 'man' ? 'm' : tile.type === 'pin' ? 'p' : 's';
+  return `${tile.value}${suffix}`;
+}
+
+export function shuffleTiles(tiles: Tile[]): Tile[] {
+  const shuffled = [...tiles];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}


### PR DESCRIPTION
- Tile型定義とインターフェースの作成
- generateFullTileSet()関数の実装（136枚の牌生成）
- TileManagerクラスによる牌の状態管理システム
- 山牌、手牌、捨て牌、鳴き牌の管理機能